### PR TITLE
Add src to package for sourcemap

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "main": "dist/src/index.js",
   "files": [
     "dist/src",
+    "src",
     "README.md",
     "LICENSE"
   ],


### PR DESCRIPTION
Close #16 

I checked the package size by `npm publish --dry-run`.

Before:
```
npm notice package size: 161.0 kB
npm notice unpacked size: 1.1 MB
```

After:

```
npm notice package size: 294.4 kB
npm notice unpacked size: 1.6 MB
```

It's acceptable, but I could make the size of the underlying data much smaller because they are just arrays of double floats. This is a TODO.